### PR TITLE
Fully qualify SchemaCreation name space

### DIFF
--- a/lib/active_record/connection_adapters/redshift/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift/schema_statements.rb
@@ -3,7 +3,7 @@
 module ActiveRecord
   module ConnectionAdapters
     module Redshift
-      class SchemaCreation < SchemaCreation
+      class SchemaCreation < ::ActiveRecord::ConnectionAdapters::SchemaCreation
         private
 
         def visit_ColumnDefinition(o)


### PR DESCRIPTION
It fixed https://github.com/pennylane-hq/activerecord7-redshift-adapter/issues/2 for us