### PR TITLE
Fix limit on int8 columns

### DIFF
--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -344,9 +344,9 @@ module ActiveRecord
 
       class << self
         def initialize_type_map(m) # :nodoc:
-          register_class_with_limit m, 'int2', Type::Integer
-          register_class_with_limit m, 'int4', Type::Integer
-          register_class_with_limit m, 'int8', Type::Integer
+          m.register_type 'int2', Type::Integer.new(limit: 2)
+          m.register_type 'int4', Type::Integer.new(limit: 4)
+          m.register_type 'int8', Type::Integer.new(limit: 8)
           m.alias_type 'oid', 'int2'
           m.register_type 'float4', Type::Float.new
           m.alias_type 'float8', 'float4'


### PR DESCRIPTION
Hi, thanks for maintaining this gem! 

I've encountered an issue that the int8 columns do not have the proper width in ActiveRecord (they have a default width of 32 bits instead.) The cause is that `register_class_with_limit` expects a SQL type like `int(8)`, and doesn't know what to do with `int8`.

This PR fixes that by properly specifying the limit. 