### PR TITLE
Use kwargs for PG::Coder.new

### DIFF
--- a/lib/active_record/connection_adapters/redshift_7_1_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_1_adapter.rb
@@ -707,7 +707,7 @@ module ActiveRecord
             PG::TextDecoder::TimestampWithoutTimeZone
           end
 
-        @timestamp_decoder = decoder_class.new(@timestamp_decoder.to_h)
+        @timestamp_decoder = decoder_class.new(**@timestamp_decoder.to_h)
         @raw_connection.type_map_for_results.add_coder(@timestamp_decoder)
         @default_timezone = ActiveRecord.default_timezone
 


### PR DESCRIPTION
Get rid of this warning on connect:

> PG::Coder.new(hash) is deprecated. Please use keyword arguments instead! Called from /usr/local/bundle/bundler/gems/activerecord-adapter-redshift-53b9fda9ce6a/lib/active_record/connection_adapters/redshift_7_1_adapter.rb:710:in `new'
