### PR TITLE
Remove deprecated `name` argument from `#tables`

### DIFF
--- a/lib/active_record/connection_adapters/redshift_7_0/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift_7_0/schema_statements.rb
@@ -57,14 +57,8 @@ module ActiveRecord
           execute "DROP DATABASE #{quote_table_name(name)}"
         end
 
-        # Returns the list of all tables in the schema search path or a specified schema.
-        def tables(name = nil)
-          if name
-            ActiveSupport::Deprecation.warn(<<-MSG.squish)
-              Passing arguments to #tables is deprecated without replacement.
-            MSG
-          end
-
+        # Returns an array of table names defined in the database.
+        def tables
           select_values('SELECT tablename FROM pg_tables WHERE schemaname = ANY(current_schemas(false))', 'SCHEMA')
         end
 

--- a/lib/active_record/connection_adapters/redshift_7_1/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift_7_1/schema_statements.rb
@@ -57,14 +57,8 @@ module ActiveRecord
           execute "DROP DATABASE #{quote_table_name(name)}"
         end
 
-        # Returns the list of all tables in the schema search path or a specified schema.
-        def tables(name = nil)
-          if name
-            ActiveSupport::Deprecation.warn(<<-MSG.squish)
-              Passing arguments to #tables is deprecated without replacement.
-            MSG
-          end
-
+        # Returns an array of table names defined in the database.
+        def tables
           select_values('SELECT tablename FROM pg_tables WHERE schemaname = ANY(current_schemas(false))', 'SCHEMA')
         end
 


### PR DESCRIPTION
The `name` argument for `#tables` was removed in Rails 5.1.0, so let's remove it here also.

- https://github.com/rails/rails/blob/5-1-stable/activerecord/CHANGELOG.md#rails-510-april-27-2017
- https://github.com/rails/rails/commit/d5be101dd02214468a27b6839ffe338cfe8ef5f3

Together with #26 this PR removes all deprecated usage of `ActiveSupport::Deprecation.warn` (see https://github.com/rails/rails/pull/47354).