### PR TITLE
Remove deprecated behaviour of `#table_exists?`

### DIFF
--- a/lib/active_record/connection_adapters/redshift_7_0/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift_7_0/schema_statements.rb
@@ -83,13 +83,17 @@ module ActiveRecord
         # If the schema is not specified as part of +name+ then it will only find tables within
         # the current schema search path (regardless of permissions to access tables in other schemas)
         def table_exists?(name)
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            #table_exists? currently checks both tables and views.
-            This behavior is deprecated and will be changed with Rails 5.1 to only check tables.
-            Use #data_source_exists? instead.
-          MSG
+          name = Utils.extract_schema_qualified_name(name.to_s)
+          return false unless name.identifier
 
-          data_source_exists?(name)
+          select_value(<<-SQL, 'SCHEMA').to_i > 0
+              SELECT COUNT(*)
+              FROM pg_class c
+              LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+              WHERE c.relkind = 'r' -- (r)elation/table
+              AND c.relname = '#{name.identifier}'
+              AND n.nspname = #{name.schema ? "'#{name.schema}'" : 'ANY (current_schemas(false))'}
+          SQL
         end
 
         def data_source_exists?(name)

--- a/lib/active_record/connection_adapters/redshift_7_1/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift_7_1/schema_statements.rb
@@ -83,13 +83,17 @@ module ActiveRecord
         # If the schema is not specified as part of +name+ then it will only find tables within
         # the current schema search path (regardless of permissions to access tables in other schemas)
         def table_exists?(name)
-          ActiveSupport::Deprecation.warn(<<-MSG.squish)
-            #table_exists? currently checks both tables and views.
-            This behavior is deprecated and will be changed with Rails 5.1 to only check tables.
-            Use #data_source_exists? instead.
-          MSG
+          name = Utils.extract_schema_qualified_name(name.to_s)
+          return false unless name.identifier
 
-          data_source_exists?(name)
+          select_value(<<-SQL, 'SCHEMA').to_i > 0
+              SELECT COUNT(*)
+              FROM pg_class c
+              LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+              WHERE c.relkind = 'r' -- (r)elation/table
+              AND c.relname = '#{name.identifier}'
+              AND n.nspname = #{name.schema ? "'#{name.schema}'" : 'ANY (current_schemas(false))'}
+          SQL
         end
 
         def data_source_exists?(name)


### PR DESCRIPTION
Since Rails 5.1 `#tables` only returns tables, not views.

- https://github.com/rails/rails/blob/5-1-stable/activerecord/CHANGELOG.md#rails-510-april-27-2017
- https://github.com/rails/rails/commit/5973a984c369a63720c2ac18b71012b8347479a8

Together with #25 this PR removes all deprecated usage of `ActiveSupport::Deprecation.warn` (see https://github.com/rails/rails/pull/47354).