### PR TITLE
Fix a bug where starting a Rails server always raised a NotImplementedError

### DIFF
--- a/lib/active_record/connection_adapters/redshift_7_1/quoting.rb
+++ b/lib/active_record/connection_adapters/redshift_7_1/quoting.rb
@@ -44,7 +44,7 @@ module ActiveRecord
 
         # Quotes column names for use in SQL queries.
         def quote_column_name(name) # :nodoc:
-          QUOTED_COLUMN_NAMES[name] ||= PG::Connection.quote_ident(super).freeze
+          QUOTED_COLUMN_NAMES[name] ||= PG::Connection.quote_ident(name.to_s).freeze
         end
 
         # Quotes schema names for use in SQL queries.

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -9,7 +9,3 @@ elsif ActiveRecord.version >= Gem::Version.new('7.0.0')
 else
   raise 'no compatible version of ActiveRecord detected'
 end
-
-if ActiveRecord.version >= Gem::Version.new('7.2.0')
-  ActiveRecord::ConnectionAdapters.register('redshift', 'ActiveRecord::ConnectionAdapters::RedshiftAdapter', 'active_record/connection_adapters/redshift_adapter')
-end

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pg'
+require 'active_record'
 require 'active_record/connection_adapters'
 
 if ActiveRecord.version >= Gem::Version.new('7.1.0')

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'pg'
+require "active_record"
+require "active_record/connection_adapters"
 
 if ActiveRecord.version >= Gem::Version.new('7.1.0')
   require_relative 'redshift_7_1_adapter'
@@ -8,4 +10,8 @@ elsif ActiveRecord.version >= Gem::Version.new('7.0.0')
   require_relative 'redshift_7_0_adapter'
 else
   raise 'no compatible version of ActiveRecord detected'
+end
+
+if ActiveRecord.version >= Gem::Version.new('7.2.0')
+  ActiveRecord::ConnectionAdapters.register("redshift", "ActiveRecord::ConnectionAdapters::RedshiftAdapter", "active_record/connection_adapters/redshift_adapter")
 end

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 require 'pg'
-require "active_record"
-require "active_record/connection_adapters"
+require 'active_record/connection_adapters'
 
 if ActiveRecord.version >= Gem::Version.new('7.1.0')
   require_relative 'redshift_7_1_adapter'
@@ -13,5 +12,5 @@ else
 end
 
 if ActiveRecord.version >= Gem::Version.new('7.2.0')
-  ActiveRecord::ConnectionAdapters.register("redshift", "ActiveRecord::ConnectionAdapters::RedshiftAdapter", "active_record/connection_adapters/redshift_adapter")
+  ActiveRecord::ConnectionAdapters.register('redshift', 'ActiveRecord::ConnectionAdapters::RedshiftAdapter', 'active_record/connection_adapters/redshift_adapter')
 end

--- a/lib/active_record/connection_adapters/redshift_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_adapter.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 require 'pg'
-require 'active_record'
-require 'active_record/connection_adapters'
 
 if ActiveRecord.version >= Gem::Version.new('7.1.0')
   require_relative 'redshift_7_1_adapter'

--- a/lib/activerecord-adapter-redshift.rb
+++ b/lib/activerecord-adapter-redshift.rb
@@ -1,5 +1,0 @@
-if ActiveRecord.version >= Gem::Version.new('7.2.0')
-  require "active_record"
-  require "active_record/connection_adapters"
-  ActiveRecord::ConnectionAdapters.register("redshift", "ActiveRecord::ConnectionAdapters::RedshiftAdapter", "active_record/connection_adapters/redshift_adapter")
-end

--- a/lib/activerecord-adapter-redshift.rb
+++ b/lib/activerecord-adapter-redshift.rb
@@ -1,0 +1,3 @@
+require "active_record"
+require "active_record/connection_adapters"
+ActiveRecord::ConnectionAdapters.register("redshift", "ActiveRecord::ConnectionAdapters::RedshiftAdapter", "active_record/connection_adapters/redshift_adapter")

--- a/lib/activerecord-adapter-redshift.rb
+++ b/lib/activerecord-adapter-redshift.rb
@@ -1,3 +1,5 @@
-require "active_record"
-require "active_record/connection_adapters"
-ActiveRecord::ConnectionAdapters.register("redshift", "ActiveRecord::ConnectionAdapters::RedshiftAdapter", "active_record/connection_adapters/redshift_adapter")
+if ActiveRecord.version >= Gem::Version.new('7.2.0')
+  require "active_record"
+  require "active_record/connection_adapters"
+  ActiveRecord::ConnectionAdapters.register("redshift", "ActiveRecord::ConnectionAdapters::RedshiftAdapter", "active_record/connection_adapters/redshift_adapter")
+end


### PR DESCRIPTION
Found a bug where the whole app crashed when starting a Rails server. 
In `Quoting#quote_column_name` it was calling the parent method, which will always raise a NotImplementedError.