### PR TITLE
Add explicit RedshiftDatabaseTasks and correct Hash/kwargs confusion

### DIFF
--- a/lib/active_record/connection_adapters/redshift_7_0/oid/decimal.rb
+++ b/lib/active_record/connection_adapters/redshift_7_0/oid/decimal.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     module Redshift
       module OID # :nodoc:
         class Decimal < Type::Decimal # :nodoc:
-          def infinity(**options)
+          def infinity(options = {})
             BigDecimal('Infinity') * (options[:negative] ? -1 : 1)
           end
         end

--- a/lib/active_record/connection_adapters/redshift_7_0/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift_7_0/schema_statements.rb
@@ -24,7 +24,7 @@ module ActiveRecord
       module SchemaStatements
         # Drops the database specified on the +name+ attribute
         # and creates it again using the provided +options+.
-        def recreate_database(name, **options) # :nodoc:
+        def recreate_database(name, options = {}) # :nodoc:
           drop_database(name)
           create_database(name, options)
         end
@@ -37,7 +37,7 @@ module ActiveRecord
         # Example:
         #   create_database config[:database], config
         #   create_database 'foo_development', encoding: 'unicode'
-        def create_database(name, **options)
+        def create_database(name, options = {})
           options = { encoding: 'utf8' }.merge!(options.symbolize_keys)
 
           option_string = options.inject('') do |memo, (key, value)|

--- a/lib/active_record/connection_adapters/redshift_7_0_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_0_adapter.rb
@@ -20,8 +20,6 @@ require 'pg'
 
 require 'ipaddr'
 
-ActiveRecord::Tasks::DatabaseTasks.register_task(/redshift/, 'ActiveRecord::Tasks::PostgreSQLDatabaseTasks')
-
 module ActiveRecord
   module ConnectionHandling # :nodoc:
     RS_VALID_CONN_PARAMS = %i[host hostaddr port dbname user password connect_timeout

--- a/lib/active_record/connection_adapters/redshift_7_1/oid/decimal.rb
+++ b/lib/active_record/connection_adapters/redshift_7_1/oid/decimal.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     module Redshift
       module OID # :nodoc:
         class Decimal < Type::Decimal # :nodoc:
-          def infinity(**options)
+          def infinity(options = {})
             BigDecimal('Infinity') * (options[:negative] ? -1 : 1)
           end
         end

--- a/lib/active_record/connection_adapters/redshift_7_1/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift_7_1/schema_statements.rb
@@ -24,7 +24,7 @@ module ActiveRecord
       module SchemaStatements
         # Drops the database specified on the +name+ attribute
         # and creates it again using the provided +options+.
-        def recreate_database(name, **options) # :nodoc:
+        def recreate_database(name, options = {}) # :nodoc:
           drop_database(name)
           create_database(name, options)
         end
@@ -37,7 +37,7 @@ module ActiveRecord
         # Example:
         #   create_database config[:database], config
         #   create_database 'foo_development', encoding: 'unicode'
-        def create_database(name, **options)
+        def create_database(name, options = {})
           options = { encoding: 'utf8' }.merge!(options.symbolize_keys)
 
           option_string = options.inject('') do |memo, (key, value)|

--- a/lib/active_record/connection_adapters/redshift_7_1_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_1_adapter.rb
@@ -20,7 +20,6 @@ require 'pg'
 
 require 'ipaddr'
 
-ActiveRecord::Tasks::DatabaseTasks.register_task(/redshift/, 'ActiveRecord::Tasks::PostgreSQLDatabaseTasks')
 module ActiveRecord
   module ConnectionHandling # :nodoc:
 

--- a/lib/active_record/connection_adapters/redshift_7_2/oid/decimal.rb
+++ b/lib/active_record/connection_adapters/redshift_7_2/oid/decimal.rb
@@ -5,7 +5,7 @@ module ActiveRecord
     module Redshift
       module OID # :nodoc:
         class Decimal < Type::Decimal # :nodoc:
-          def infinity(**options)
+          def infinity(options = {})
             BigDecimal('Infinity') * (options[:negative] ? -1 : 1)
           end
         end

--- a/lib/active_record/connection_adapters/redshift_7_2/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift_7_2/schema_statements.rb
@@ -24,7 +24,7 @@ module ActiveRecord
       module SchemaStatements
         # Drops the database specified on the +name+ attribute
         # and creates it again using the provided +options+.
-        def recreate_database(name, **options) # :nodoc:
+        def recreate_database(name, options = {}) # :nodoc:
           drop_database(name)
           create_database(name, options)
         end
@@ -37,7 +37,7 @@ module ActiveRecord
         # Example:
         #   create_database config[:database], config
         #   create_database 'foo_development', encoding: 'unicode'
-        def create_database(name, **options)
+        def create_database(name, options = {})
           options = { encoding: 'utf8' }.merge!(options.symbolize_keys)
 
           option_string = options.inject('') do |memo, (key, value)|

--- a/lib/active_record/connection_adapters/redshift_7_2_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_2_adapter.rb
@@ -20,7 +20,6 @@ require 'pg'
 
 require 'ipaddr'
 
-ActiveRecord::Tasks::DatabaseTasks.register_task(/redshift/, 'ActiveRecord::Tasks::PostgreSQLDatabaseTasks')
 module ActiveRecord
   module ConnectionHandling # :nodoc:
 

--- a/lib/active_record/tasks/redshift_7_0_tasks.rb
+++ b/lib/active_record/tasks/redshift_7_0_tasks.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+# Based on https://github.com/rails/rails/blob/v7.0.8.4/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+
+require "tempfile"
+
+module ActiveRecord
+  module Tasks # :nodoc:
+    class RedshiftDatabaseTasks # :nodoc:
+      DEFAULT_ENCODING = ENV["CHARSET"] || "utf8"
+      ON_ERROR_STOP_1 = "ON_ERROR_STOP=1"
+      SQL_COMMENT_BEGIN = "--"
+
+      delegate :connection, :establish_connection, :clear_active_connections!,
+        to: ActiveRecord::Base
+
+      def self.using_database_configurations?
+        true
+      end
+
+      def initialize(db_config)
+        @db_config = db_config
+        @configuration_hash = db_config.configuration_hash
+      end
+
+      def create(master_established = false)
+        establish_master_connection unless master_established
+        connection.create_database(db_config.database, configuration_hash.merge(encoding: encoding))
+        establish_connection(db_config)
+      end
+
+      def drop
+        establish_master_connection
+        connection.drop_database(db_config.database)
+      end
+
+      def charset
+        connection.encoding
+      end
+
+      def collation
+        connection.collation
+      end
+
+      def purge
+        clear_active_connections!
+        drop
+        create true
+      end
+
+      def structure_dump(filename, extra_flags)
+        search_path = \
+          case ActiveRecord.dump_schemas
+          when :schema_search_path
+            configuration_hash[:schema_search_path]
+          when :all
+            nil
+          when String
+            ActiveRecord.dump_schemas
+          end
+
+        args = ["--schema-only", "--no-privileges", "--no-owner"]
+        args.concat(["--file", filename])
+
+        args.concat(Array(extra_flags)) if extra_flags
+
+        unless search_path.blank?
+          args += search_path.split(",").map do |part|
+            "--schema=#{part.strip}"
+          end
+        end
+
+        ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
+        if ignore_tables.any?
+          args += ignore_tables.flat_map { |table| ["-T", table] }
+        end
+
+        args << db_config.database
+        run_cmd("pg_dump", args, "dumping")
+        remove_sql_header_comments(filename)
+        File.open(filename, "a") { |f| f << "SET search_path TO #{connection.schema_search_path};\n\n" }
+      end
+
+      def structure_load(filename, extra_flags)
+        args = ["--set", ON_ERROR_STOP_1, "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename]
+        args.concat(Array(extra_flags)) if extra_flags
+        args << db_config.database
+        run_cmd("psql", args, "loading")
+      end
+
+      private
+        attr_reader :db_config, :configuration_hash
+
+        def encoding
+          configuration_hash[:encoding] || DEFAULT_ENCODING
+        end
+
+        def establish_master_connection
+          establish_connection configuration_hash.merge(
+            database: "redshift",
+            schema_search_path: "public"
+          )
+        end
+
+        def psql_env
+          {}.tap do |env|
+            env["PGHOST"]         = db_config.host                        if db_config.host
+            env["PGPORT"]         = configuration_hash[:port].to_s        if configuration_hash[:port]
+            env["PGPASSWORD"]     = configuration_hash[:password].to_s    if configuration_hash[:password]
+            env["PGUSER"]         = configuration_hash[:username].to_s    if configuration_hash[:username]
+            env["PGSSLMODE"]      = configuration_hash[:sslmode].to_s     if configuration_hash[:sslmode]
+            env["PGSSLCERT"]      = configuration_hash[:sslcert].to_s     if configuration_hash[:sslcert]
+            env["PGSSLKEY"]       = configuration_hash[:sslkey].to_s      if configuration_hash[:sslkey]
+            env["PGSSLROOTCERT"]  = configuration_hash[:sslrootcert].to_s if configuration_hash[:sslrootcert]
+          end
+        end
+
+        def run_cmd(cmd, args, action)
+          fail run_cmd_error(cmd, args, action) unless Kernel.system(psql_env, cmd, *args)
+        end
+
+        def run_cmd_error(cmd, args, action)
+          msg = +"failed to execute:\n"
+          msg << "#{cmd} #{args.join(' ')}\n\n"
+          msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"
+          msg
+        end
+
+        def remove_sql_header_comments(filename)
+          removing_comments = true
+          tempfile = Tempfile.open("uncommented_structure.sql")
+          begin
+            File.foreach(filename) do |line|
+              unless removing_comments && (line.start_with?(SQL_COMMENT_BEGIN) || line.blank?)
+                tempfile << line
+                removing_comments = false
+              end
+            end
+          ensure
+            tempfile.close
+          end
+          FileUtils.cp(tempfile.path, filename)
+        end
+    end
+
+    DatabaseTasks.register_task(/redshift/, RedshiftDatabaseTasks)
+  end
+end

--- a/lib/active_record/tasks/redshift_7_1_tasks.rb
+++ b/lib/active_record/tasks/redshift_7_1_tasks.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+# Based on https://github.com/rails/rails/blob/v7.1.4/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+
+require "tempfile"
+
+module ActiveRecord
+  module Tasks # :nodoc:
+    class RedshiftDatabaseTasks # :nodoc:
+      DEFAULT_ENCODING = ENV["CHARSET"] || "utf8"
+      ON_ERROR_STOP_1 = "ON_ERROR_STOP=1"
+      SQL_COMMENT_BEGIN = "--"
+
+      def self.using_database_configurations?
+        true
+      end
+
+      def initialize(db_config)
+        @db_config = db_config
+        @configuration_hash = db_config.configuration_hash
+      end
+
+      def create(connection_already_established = false)
+        establish_connection(public_schema_config) unless connection_already_established
+        connection.create_database(db_config.database, configuration_hash.merge(encoding: encoding))
+        establish_connection
+      end
+
+      def drop
+        establish_connection(public_schema_config)
+        connection.drop_database(db_config.database)
+      end
+
+      def charset
+        connection.encoding
+      end
+
+      def collation
+        connection.collation
+      end
+
+      def purge
+        ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+        drop
+        create true
+      end
+
+      def structure_dump(filename, extra_flags)
+        search_path = \
+          case ActiveRecord.dump_schemas
+          when :schema_search_path
+            configuration_hash[:schema_search_path]
+          when :all
+            nil
+          when String
+            ActiveRecord.dump_schemas
+          end
+
+        args = ["--schema-only", "--no-privileges", "--no-owner"]
+        args.concat(["--file", filename])
+
+        args.concat(Array(extra_flags)) if extra_flags
+
+        unless search_path.blank?
+          args += search_path.split(",").map do |part|
+            "--schema=#{part.strip}"
+          end
+        end
+
+        ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
+        if ignore_tables.any?
+          ignore_tables = connection.data_sources.select { |table| ignore_tables.any? { |pattern| pattern === table } }
+          args += ignore_tables.flat_map { |table| ["-T", table] }
+        end
+
+        args << db_config.database
+        run_cmd("pg_dump", args, "dumping")
+        remove_sql_header_comments(filename)
+        File.open(filename, "a") { |f| f << "SET search_path TO #{connection.schema_search_path};\n\n" }
+      end
+
+      def structure_load(filename, extra_flags)
+        args = ["--set", ON_ERROR_STOP_1, "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename]
+        args.concat(Array(extra_flags)) if extra_flags
+        args << db_config.database
+        run_cmd("psql", args, "loading")
+      end
+
+      private
+        attr_reader :db_config, :configuration_hash
+
+        def connection
+          ActiveRecord::Base.connection
+        end
+
+        def establish_connection(config = db_config)
+          ActiveRecord::Base.establish_connection(config)
+        end
+
+        def encoding
+          configuration_hash[:encoding] || DEFAULT_ENCODING
+        end
+
+        def public_schema_config
+          configuration_hash.merge(database: "redshift", schema_search_path: "public")
+        end
+
+        def psql_env
+          {}.tap do |env|
+            env["PGHOST"]         = db_config.host                        if db_config.host
+            env["PGPORT"]         = configuration_hash[:port].to_s        if configuration_hash[:port]
+            env["PGPASSWORD"]     = configuration_hash[:password].to_s    if configuration_hash[:password]
+            env["PGUSER"]         = configuration_hash[:username].to_s    if configuration_hash[:username]
+            env["PGSSLMODE"]      = configuration_hash[:sslmode].to_s     if configuration_hash[:sslmode]
+            env["PGSSLCERT"]      = configuration_hash[:sslcert].to_s     if configuration_hash[:sslcert]
+            env["PGSSLKEY"]       = configuration_hash[:sslkey].to_s      if configuration_hash[:sslkey]
+            env["PGSSLROOTCERT"]  = configuration_hash[:sslrootcert].to_s if configuration_hash[:sslrootcert]
+          end
+        end
+
+        def run_cmd(cmd, args, action)
+          fail run_cmd_error(cmd, args, action) unless Kernel.system(psql_env, cmd, *args)
+        end
+
+        def run_cmd_error(cmd, args, action)
+          msg = +"failed to execute:\n"
+          msg << "#{cmd} #{args.join(' ')}\n\n"
+          msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"
+          msg
+        end
+
+        def remove_sql_header_comments(filename)
+          removing_comments = true
+          tempfile = Tempfile.open("uncommented_structure.sql")
+          begin
+            File.foreach(filename) do |line|
+              unless removing_comments && (line.start_with?(SQL_COMMENT_BEGIN) || line.blank?)
+                tempfile << line
+                removing_comments = false
+              end
+            end
+          ensure
+            tempfile.close
+          end
+          FileUtils.cp(tempfile.path, filename)
+        end
+    end
+
+    DatabaseTasks.register_task(/redshift/, RedshiftDatabaseTasks)
+  end
+end

--- a/lib/active_record/tasks/redshift_7_2_tasks.rb
+++ b/lib/active_record/tasks/redshift_7_2_tasks.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+# Based on https://github.com/rails/rails/blob/v7.2.1/activerecord/lib/active_record/tasks/postgresql_database_tasks.rb
+
+require "tempfile"
+
+module ActiveRecord
+  module Tasks # :nodoc:
+    class RedshiftDatabaseTasks # :nodoc:
+      DEFAULT_ENCODING = ENV["CHARSET"] || "utf8"
+      ON_ERROR_STOP_1 = "ON_ERROR_STOP=1"
+      SQL_COMMENT_BEGIN = "--"
+
+      def self.using_database_configurations?
+        true
+      end
+
+      def initialize(db_config)
+        @db_config = db_config
+        @configuration_hash = db_config.configuration_hash
+      end
+
+      def create(connection_already_established = false)
+        establish_connection(public_schema_config) unless connection_already_established
+        connection.create_database(db_config.database, configuration_hash.merge(encoding: encoding))
+        establish_connection
+      end
+
+      def drop
+        establish_connection(public_schema_config)
+        connection.drop_database(db_config.database)
+      end
+
+      def charset
+        connection.encoding
+      end
+
+      def collation
+        connection.collation
+      end
+
+      def purge
+        ActiveRecord::Base.connection_handler.clear_active_connections!(:all)
+        drop
+        create true
+      end
+
+      def structure_dump(filename, extra_flags)
+        search_path = \
+          case ActiveRecord.dump_schemas
+          when :schema_search_path
+            configuration_hash[:schema_search_path]
+          when :all
+            nil
+          when String
+            ActiveRecord.dump_schemas
+          end
+
+        args = ["--schema-only", "--no-privileges", "--no-owner"]
+        args.concat(["--file", filename])
+
+        args.concat(Array(extra_flags)) if extra_flags
+
+        unless search_path.blank?
+          args += search_path.split(",").map do |part|
+            "--schema=#{part.strip}"
+          end
+        end
+
+        ignore_tables = ActiveRecord::SchemaDumper.ignore_tables
+        if ignore_tables.any?
+          ignore_tables = connection.data_sources.select { |table| ignore_tables.any? { |pattern| pattern === table } }
+          args += ignore_tables.flat_map { |table| ["-T", table] }
+        end
+
+        args << db_config.database
+        run_cmd("pg_dump", args, "dumping")
+        remove_sql_header_comments(filename)
+        File.open(filename, "a") { |f| f << "SET search_path TO #{connection.schema_search_path};\n\n" }
+      end
+
+      def structure_load(filename, extra_flags)
+        args = ["--set", ON_ERROR_STOP_1, "--quiet", "--no-psqlrc", "--output", File::NULL, "--file", filename]
+        args.concat(Array(extra_flags)) if extra_flags
+        args << db_config.database
+        run_cmd("psql", args, "loading")
+      end
+
+      private
+        attr_reader :db_config, :configuration_hash
+
+        def connection
+          ActiveRecord::Base.lease_connection
+        end
+
+        def establish_connection(config = db_config)
+          ActiveRecord::Base.establish_connection(config)
+        end
+
+        def encoding
+          configuration_hash[:encoding] || DEFAULT_ENCODING
+        end
+
+        def public_schema_config
+          configuration_hash.merge(database: "redshift", schema_search_path: "public")
+        end
+
+        def psql_env
+          {}.tap do |env|
+            env["PGHOST"]         = db_config.host                        if db_config.host
+            env["PGPORT"]         = configuration_hash[:port].to_s        if configuration_hash[:port]
+            env["PGPASSWORD"]     = configuration_hash[:password].to_s    if configuration_hash[:password]
+            env["PGUSER"]         = configuration_hash[:username].to_s    if configuration_hash[:username]
+            env["PGSSLMODE"]      = configuration_hash[:sslmode].to_s     if configuration_hash[:sslmode]
+            env["PGSSLCERT"]      = configuration_hash[:sslcert].to_s     if configuration_hash[:sslcert]
+            env["PGSSLKEY"]       = configuration_hash[:sslkey].to_s      if configuration_hash[:sslkey]
+            env["PGSSLROOTCERT"]  = configuration_hash[:sslrootcert].to_s if configuration_hash[:sslrootcert]
+          end
+        end
+
+        def run_cmd(cmd, args, action)
+          fail run_cmd_error(cmd, args, action) unless Kernel.system(psql_env, cmd, *args)
+        end
+
+        def run_cmd_error(cmd, args, action)
+          msg = +"failed to execute:\n"
+          msg << "#{cmd} #{args.join(' ')}\n\n"
+          msg << "Please check the output above for any errors and make sure that `#{cmd}` is installed in your PATH and has proper permissions.\n\n"
+          msg
+        end
+
+        def remove_sql_header_comments(filename)
+          removing_comments = true
+          tempfile = Tempfile.open("uncommented_structure.sql")
+          begin
+            File.foreach(filename) do |line|
+              unless removing_comments && (line.start_with?(SQL_COMMENT_BEGIN) || line.blank?)
+                tempfile << line
+                removing_comments = false
+              end
+            end
+          ensure
+            tempfile.close
+          end
+          FileUtils.cp(tempfile.path, filename)
+        end
+    end
+
+    DatabaseTasks.register_task(/redshift/, RedshiftDatabaseTasks)
+  end
+end

--- a/lib/active_record/tasks/redshift_tasks.rb
+++ b/lib/active_record/tasks/redshift_tasks.rb
@@ -1,15 +1,11 @@
 # frozen_string_literal: true
 
-require 'pg'
-
-require_relative "../tasks/redshift_tasks"
-
 if ActiveRecord.version >= Gem::Version.new('7.2.0')
-  require_relative 'redshift_7_2_adapter'
+  require_relative 'redshift_7_2_tasks'
 elsif ActiveRecord.version >= Gem::Version.new('7.1.0')
-  require_relative 'redshift_7_1_adapter'
+  require_relative 'redshift_7_1_tasks'
 elsif ActiveRecord.version >= Gem::Version.new('7.0.0')
-  require_relative 'redshift_7_0_adapter'
+  require_relative 'redshift_7_0_tasks'
 else
   raise 'no compatible version of ActiveRecord detected'
 end


### PR DESCRIPTION
With this change `rake db:create db:schema:dump db:drop` no longer errors with the Redshift adapter.

This PR partially reverts:

https://github.com/pennylane-hq/activerecord-adapter-redshift/commit/1ce6bdbcba7ade96960886895e7ff1f85d5263c0

to be in-line with the Postgres adapter, where some Hash options still remain and haven't been converted to kwargs.

This avoids the error:
```
~/.rbenv/versions/3.3.3/lib/ruby/gems/3.3.0/gems/activerecord7-redshift-adapter-pennylane-1.0.4/lib/active_record/connection_adapters/redshift_7_1/schema_statements.rb:40:in `create_database': wrong number of arguments (given 2, expected 1) (ArgumentError)
```

It also adds an explicit (copy-pasted from the relevant `PostgreSQLDatabaseTasks` in Rails) `RedshiftDatabaseTasks` for Redshift. The only change is to make the public schema connection to a database named `redshift` not `postgres`. Without the override, attempting to use the database tasks errors with
```
connection to server at "X.Y.Z.W", port 5439 failed: FATAL:  database "postgres" does not exist
```
