### PR TITLE
Map PG::DuplicateDatabase error to ActiveRecord::DatabaseAlreadyExists

### DIFF
--- a/lib/active_record/connection_adapters/redshift_7_1_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_1_adapter.rb
@@ -353,13 +353,17 @@ module ActiveRecord
       def translate_exception(exception, message:, sql:, binds:)
         return exception unless exception.respond_to?(:result)
 
-        case exception.message
-        when /duplicate key value violates unique constraint/
-          RecordNotUnique.new(message, exception)
-        when /violates foreign key constraint/
-          InvalidForeignKey.new(message, exception)
+        if exception.is_a?(PG::DuplicateDatabase)
+          DatabaseAlreadyExists.new(message, sql: sql, binds: binds)
         else
-          super
+          case exception.message
+          when /duplicate key value violates unique constraint/
+            RecordNotUnique.new(message, exception)
+          when /violates foreign key constraint/
+            InvalidForeignKey.new(message, exception)
+          else
+            super
+          end
         end
       end
 

--- a/lib/active_record/connection_adapters/redshift_7_2_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_2_adapter.rb
@@ -353,13 +353,17 @@ module ActiveRecord
       def translate_exception(exception, message:, sql:, binds:)
         return exception unless exception.respond_to?(:result)
 
-        case exception.message
-        when /duplicate key value violates unique constraint/
-          RecordNotUnique.new(message, exception)
-        when /violates foreign key constraint/
-          InvalidForeignKey.new(message, exception)
+        if exception.is_a?(PG::DuplicateDatabase)
+          DatabaseAlreadyExists.new(message, sql: sql, binds: binds)
         else
-          super
+          case exception.message
+          when /duplicate key value violates unique constraint/
+            RecordNotUnique.new(message, exception)
+          when /violates foreign key constraint/
+            InvalidForeignKey.new(message, exception)
+          else
+            super
+          end
         end
       end
 


### PR DESCRIPTION
As per https://github.com/rails/rails/pull/36782

To avoid an error in `db:migrate` when the database already exists:
```
PG::DuplicateDatabase: ERROR:  database "owst_testing" already exists
Couldn't create 'owst_testing' database. Please check your configuration.
rake aborted!
ActiveRecord::StatementInvalid: PG::DuplicateDatabase: ERROR:  database "owst_testing" already exists (ActiveRecord::StatementInvalid)
```

after this PR we see a message without error:
```
Database 'owst_testing' already exists
```