### PR TITLE
Remove unnecessary exception mapping for constraint violations

### DIFF
--- a/lib/active_record/connection_adapters/redshift_7_0_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_0_adapter.rb
@@ -333,14 +333,7 @@ module ActiveRecord
         if exception.is_a?(PG::DuplicateDatabase)
           DatabaseAlreadyExists.new(message, sql: sql, binds: binds)
         else
-          case exception.message
-          when /duplicate key value violates unique constraint/
-            RecordNotUnique.new(message, exception)
-          when /violates foreign key constraint/
-            InvalidForeignKey.new(message, exception)
-          else
-            super
-          end
+          super
         end
       end
 

--- a/lib/active_record/connection_adapters/redshift_7_1_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_1_adapter.rb
@@ -356,14 +356,7 @@ module ActiveRecord
         if exception.is_a?(PG::DuplicateDatabase)
           DatabaseAlreadyExists.new(message, sql: sql, binds: binds)
         else
-          case exception.message
-          when /duplicate key value violates unique constraint/
-            RecordNotUnique.new(message, exception)
-          when /violates foreign key constraint/
-            InvalidForeignKey.new(message, exception)
-          else
-            super
-          end
+          super
         end
       end
 

--- a/lib/active_record/connection_adapters/redshift_7_2_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_2_adapter.rb
@@ -356,14 +356,7 @@ module ActiveRecord
         if exception.is_a?(PG::DuplicateDatabase)
           DatabaseAlreadyExists.new(message, sql: sql, binds: binds)
         else
-          case exception.message
-          when /duplicate key value violates unique constraint/
-            RecordNotUnique.new(message, exception)
-          when /violates foreign key constraint/
-            InvalidForeignKey.new(message, exception)
-          else
-            super
-          end
+          super
         end
       end
 


### PR DESCRIPTION
Redshift does not enforce uniqueness or foreign key constraints, so the related exceptions should never happen:
https://docs.aws.amazon.com/redshift/latest/dg/t_Defining_constraints.html

As discussed in a previous PR: https://github.com/pennylane-hq/activerecord-adapter-redshift/pull/42/files#r1857082754