### PR TITLE
Reproduce Rails PG adapter changes

### DIFF
--- a/lib/active_record/connection_adapters/redshift_7_0/database_statements.rb
+++ b/lib/active_record/connection_adapters/redshift_7_0/database_statements.rb
@@ -207,6 +207,11 @@ module ActiveRecord
           end
         end
 
+        # Returns the current ID of a table's sequence.
+        def last_insert_id_result(sequence_name)
+          internal_exec_query("SELECT currval(#{quote(sequence_name)})", "SQL")
+        end
+
         # Begins a transaction.
         def begin_db_transaction
           execute 'BEGIN'

--- a/lib/active_record/connection_adapters/redshift_7_0/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift_7_0/schema_statements.rb
@@ -220,13 +220,13 @@ module ActiveRecord
         end
 
         # Returns the sequence name for a table's primary key or some other specified key.
-        def default_sequence_name(table_name, pk = nil) # :nodoc:
-          result = serial_sequence(table_name, pk || 'id')
+        def default_sequence_name(table_name, pk = "id") # :nodoc:
+          result = serial_sequence(table_name, pk)
           return nil unless result
 
           Utils.extract_schema_qualified_name(result).to_s
         rescue ActiveRecord::StatementInvalid
-          Redshift::Name.new(nil, "#{table_name}_#{pk || 'id'}_seq").to_s
+          Redshift::Name.new(nil, "#{table_name}_#{pk}_seq").to_s
         end
 
         def serial_sequence(table, column)

--- a/lib/active_record/connection_adapters/redshift_7_0/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift_7_0/schema_statements.rb
@@ -230,7 +230,7 @@ module ActiveRecord
         end
 
         def serial_sequence(table, column)
-          select_value("SELECT pg_get_serial_sequence('#{table}', '#{column}')", 'SCHEMA')
+          select_value("SELECT pg_get_serial_sequence(#{quote(table)}, #{quote(column)})", 'SCHEMA')
         end
 
         def set_pk_sequence!(table, value); end

--- a/lib/active_record/connection_adapters/redshift_7_0_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_0_adapter.rb
@@ -616,10 +616,6 @@ module ActiveRecord
         end
       end
 
-      def last_insert_id_result(sequence_name) # :nodoc:
-        exec_query("SELECT currval('#{sequence_name}')", 'SQL')
-      end
-
       # Returns the list of a table's column names, data types, and default values.
       #
       # The underlying query is roughly:

--- a/lib/active_record/connection_adapters/redshift_7_0_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_0_adapter.rb
@@ -647,8 +647,9 @@ module ActiveRecord
       end
 
       def extract_table_ref_from_insert_sql(sql)
-        sql[/into\s("[A-Za-z0-9_."\[\]\s]+"|[A-Za-z0-9_."\[\]]+)\s*/im]
-        Regexp.last_match(1)&.strip
+        if sql =~ /into\s("[A-Za-z0-9_."\[\]\s]+"|[A-Za-z0-9_."\[\]]+)\s*/im
+          $1.delete('"').strip
+        end
       end
 
       def arel_visitor

--- a/lib/active_record/connection_adapters/redshift_7_1/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift_7_1/schema_statements.rb
@@ -220,13 +220,13 @@ module ActiveRecord
         end
 
         # Returns the sequence name for a table's primary key or some other specified key.
-        def default_sequence_name(table_name, pk = nil) # :nodoc:
-          result = serial_sequence(table_name, pk || 'id')
+        def default_sequence_name(table_name, pk = 'id') # :nodoc:
+          result = serial_sequence(table_name, pk)
           return nil unless result
 
           Utils.extract_schema_qualified_name(result).to_s
         rescue ActiveRecord::StatementInvalid
-          Redshift::Name.new(nil, "#{table_name}_#{pk || 'id'}_seq").to_s
+          Redshift::Name.new(nil, "#{table_name}_#{pk}_seq").to_s
         end
 
         def serial_sequence(table, column)

--- a/lib/active_record/connection_adapters/redshift_7_1/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift_7_1/schema_statements.rb
@@ -230,7 +230,7 @@ module ActiveRecord
         end
 
         def serial_sequence(table, column)
-          select_value("SELECT pg_get_serial_sequence('#{table}', '#{column}')", 'SCHEMA')
+          select_value("SELECT pg_get_serial_sequence(#{quote(table)}, #{quote(column)})", 'SCHEMA')
         end
 
         def set_pk_sequence!(table, value); end

--- a/lib/active_record/connection_adapters/redshift_7_1_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_1_adapter.rb
@@ -720,11 +720,6 @@ module ActiveRecord
         END_SQL
       end
 
-      def extract_table_ref_from_insert_sql(sql)
-        sql[/into\s("[A-Za-z0-9_."\[\]\s]+"|[A-Za-z0-9_."\[\]]+)\s*/im]
-        Regexp.last_match(1)&.strip
-      end
-
       def arel_visitor
         Arel::Visitors::PostgreSQL.new(self)
       end

--- a/lib/active_record/connection_adapters/redshift_7_1_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_1_adapter.rb
@@ -689,11 +689,6 @@ module ActiveRecord
         end
       end
 
-      def last_insert_id_result(sequence_name)
-        # :nodoc:
-        exec_query("SELECT currval('#{sequence_name}')", 'SQL')
-      end
-
       # Returns the list of a table's column names, data types, and default values.
       #
       # The underlying query is roughly:

--- a/lib/active_record/connection_adapters/redshift_7_2/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift_7_2/schema_statements.rb
@@ -220,13 +220,13 @@ module ActiveRecord
         end
 
         # Returns the sequence name for a table's primary key or some other specified key.
-        def default_sequence_name(table_name, pk = nil) # :nodoc:
-          result = serial_sequence(table_name, pk || 'id')
+        def default_sequence_name(table_name, pk = 'id') # :nodoc:
+          result = serial_sequence(table_name, pk)
           return nil unless result
 
           Utils.extract_schema_qualified_name(result).to_s
         rescue ActiveRecord::StatementInvalid
-          Redshift::Name.new(nil, "#{table_name}_#{pk || 'id'}_seq").to_s
+          Redshift::Name.new(nil, "#{table_name}_#{pk}_seq").to_s
         end
 
         def serial_sequence(table, column)

--- a/lib/active_record/connection_adapters/redshift_7_2/schema_statements.rb
+++ b/lib/active_record/connection_adapters/redshift_7_2/schema_statements.rb
@@ -230,7 +230,7 @@ module ActiveRecord
         end
 
         def serial_sequence(table, column)
-          select_value("SELECT pg_get_serial_sequence('#{table}', '#{column}')", 'SCHEMA')
+          select_value("SELECT pg_get_serial_sequence(#{quote(table)}, #{quote(column)})".tap { puts _1 }, 'SCHEMA')
         end
 
         def set_pk_sequence!(table, value); end

--- a/lib/active_record/connection_adapters/redshift_7_2_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_2_adapter.rb
@@ -720,11 +720,6 @@ module ActiveRecord
         END_SQL
       end
 
-      def extract_table_ref_from_insert_sql(sql)
-        sql[/into\s("[A-Za-z0-9_."\[\]\s]+"|[A-Za-z0-9_."\[\]]+)\s*/im]
-        Regexp.last_match(1)&.strip
-      end
-
       def arel_visitor
         Arel::Visitors::PostgreSQL.new(self)
       end

--- a/lib/active_record/connection_adapters/redshift_7_2_adapter.rb
+++ b/lib/active_record/connection_adapters/redshift_7_2_adapter.rb
@@ -689,11 +689,6 @@ module ActiveRecord
         end
       end
 
-      def last_insert_id_result(sequence_name)
-        # :nodoc:
-        exec_query("SELECT currval('#{sequence_name}')", 'SQL')
-      end
-
       # Returns the list of a table's column names, data types, and default values.
       #
       # The underlying query is roughly:


### PR DESCRIPTION
Pull in some upstream changes:

https://github.com/rails/rails/pull/49544/files
https://github.com/rails/rails/commit/ede8da4b26bd24aec746dcd8efa864b2e43e075e
https://github.com/rails/rails/commit/6bb46ae2e8979479ba5603b50d8e07e07b46ba6d

This fixes some issues whereby using `activerecord-import` to insert records to a table in a separate schema that didn't have a PK caused errors due to various malformed queries

@januszm FYI